### PR TITLE
Fix arrowbottom to arrowdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 1.0.1
-* preventDefault するキー `ArrowBottom` を `ArrowDown` へ修正
+* `ArrowDown` を preventDefault() できていなかった問題を修正
 
 ## 1.0.0
 * 初期リリース

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
 
+## 1.0.1
+* preventDefault するキー `ArrowBottom` を `ArrowDown` へ修正
+
 ## 1.0.0
 * 初期リリース

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic-extension/akashic-keyboard-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic-extension/akashic-keyboard-plugin",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@akashic/akashic-engine": "~3.16.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-keyboard-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A plugin handling keyboard events easily for Akashic Engine",
   "main": "lib/index.js",
   "repository": {

--- a/src/KeyboardOperationPlugin.ts
+++ b/src/KeyboardOperationPlugin.ts
@@ -22,7 +22,7 @@ export class KeyboardOperationPlugin implements g.OperationPlugin {
 		ArrowLeft: true,
 		ArrowUp: true,
 		ArrowRight: true,
-		ArrowBottom: true,
+		ArrowDown: true,
 		F1: true,
 		F2: true,
 		F3: true,


### PR DESCRIPTION
## 概要

preventDefault するキーの `ArrowBottom` を `ArrowDown` へ修正。issues #5 

**動作確認**

サンプルの `ArrowDown` のバスで console.log にて確認。

